### PR TITLE
Use better encryption for PKCS#8 key files

### DIFF
--- a/extras/make_key
+++ b/extras/make_key
@@ -73,7 +73,7 @@ else
   echo "creating ${1}.pk8 with password [${password}]"
   export password
   openssl pkcs8 -in ${one} -topk8 -outform DER -out $1.pk8 \
-    -passout env:password
+    -passout env:password -v2 "aes-256-cbc"
   unset password
 fi
 


### PR DESCRIPTION
The openssl default is apparently "PBES1" - PBDKDF1-MD5 with DES-CBC (see https://tools.ietf.org/html/rfc2898#appendix-A.3)