### PR TITLE
Add CLI flag support and flags for optional tor support and custom myapplist.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+/keys/
+/images/
+/packages/*.apk
+/packages/*.apk.asc
+/packages/gapps-delta*.xz
+/packages/gapps-delta*.xz.asc
+/packages/trustdb.gpg
+/*-factory*.tar.xz
+/*-factory*.tar.xz.sig
+/*-ota_update*.zip
+/angler-*/
+/bullhead-*/
+/flounder-*/
+/*-update.zip
+/*-update-signed.zip
+*.pyc
+/update/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Your phone will need to have **OEM Unlocking** enabled:
 1. Go to *Settings > About Phone*.
 2. Tap *Build Number* five times.
 3. Go to newly created *Settings > Developer Options*
-4. Check *Enable OEM unlock*
+4. Enable *OEM unlocking*
 
 There are some other things, but the scripts will download them.
 
@@ -53,12 +53,15 @@ To ensure the these downloads are fetched via Tor:
 
 ## Instructions
 
-There are a ton of scripts in here. Eventually, we want to make it possible to
-choose if you want Google Apps, SuperUser, Tor, or some subset. For now, the
-best thing to do is just run `./run_all.sh`. The script should walk you through
-everything, printing out instructions (and command output) as it goes. It will
-halt on any error, but you can re-run it from the top or run pieces of it
-individually.
+It is possible to choose if you want to install Tor, and eventually we want
+to make it possible to choose if you want Google Apps and/or SuperUser.
+
+To get started run `./run_all.sh -h` to see the options.  As a bare minimum you
+must provide a path to th Copperhead image for your device.
+
+The script will walk you through everything, printing out instructions (and
+command output) as it goes. It will halt on any error, but you can re-run it
+from the top or run pieces of it individually.
 
 Below is an example for the `angler` build:
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,14 @@ Below is an example for the `angler` build:
 ### Install
 
 1. **Download** your factory image and its signature from
-the [CopperheadOS download page][copperhead-download], and place it the
-git root directory.
+   the [CopperheadOS download page][copperhead-download], and place it the git
+   root directory.
+
+   You can use the `get-release-image.py` script to get the latest image for your
+   your device and to automatically validate the signature, for example:
+
+        $ get-release-image.py angler
+
 2. **Run** the following:
 
         $ gpg --recv-keys 65EEFE022108E2B708CBFCF7F9E712E59AF5F22A
@@ -80,7 +86,7 @@ update the phone. Keep them safe, and do not lose them.
 
 ### Update
 
-1. **Download** a new Copperhead image as above,
+1. **Download** a new Copperhead image as above.
 2. **Prepare your device keys.** Make sure they are in the `keys/`
    directory.
 3. **Run** the following:

--- a/fetch-apks.sh
+++ b/fetch-apks.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
+# vim:ts=2 sw=2 sts=2 expandtab:
 
-APPS=( $(cat apk_url_list.txt) )
+if [ $NO_TOR -eq 1 ]; then
+  APPS=( $(grep -Ev "^[[:space:]]*([#]|$)" apk_url_list.txt | grep -Ev 'orwall|orbot') )
+  for REMOVE in orwall orbot; do
+    rm -f packages/*${REMOVE}*.apk
+    rm -f packages/*${REMOVE}*.apk.asc
+  done
+else
+  APPS=( $(grep -Ev "^[[:space:]]*([#]|$)" apk_url_list.txt) )
+fi
 
 set -e
 

--- a/flash-signed.sh
+++ b/flash-signed.sh
@@ -18,6 +18,9 @@ fastboot flash recovery ./images/recovery-signed.img
 fastboot flash system ./images/system-signed.img
 fastboot flash boot ./images/boot-signed.img
 fastboot flash vendor ./images/vendor-signed.img
+
+# Occasionally a sleep is needed here for the lock to be successful
+sleep 5
 fastboot flashing lock
 
 echo

--- a/flash-signed.sh
+++ b/flash-signed.sh
@@ -21,7 +21,13 @@ fastboot flash vendor ./images/vendor-signed.img
 fastboot flashing lock
 
 echo
-echo "Please reboot phone into system. You can skip the Google Account Setup,"
-echo "but don't forget to set the clock properly or Orbot won't work."
+echo "Please reboot phone into system.  The first boot can take several minutes, be patient."
+echo
+
+if [ $NO_TOR -eq 0 ]; then
+  echo "Remember to set the clock properly or Orbot won't work."
+  echo
+fi
+
 echo -n "[Hit Enter to continue...]"
 read junk

--- a/get-release-image.py
+++ b/get-release-image.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# vim:set ts=4 sw=4 sts=4 expandtab:
+
+from json import loads
+from requests import get
+from os.path import exists
+from subprocess import run, CalledProcessError
+import argparse
+
+latest = { 'angler': { 'timestamp': 0 },
+           'bullhead': { 'timestamp': 0 },
+           'flounder': { 'timestamp': 0 }
+         }
+
+def getReleases():
+    """Return the list of release from Copperhead"""
+    response = get('https://update.copperhead.co/releases.json')
+    return loads(response.text)
+
+def filterByLatest(releases):
+    """Iterate the known devices as listed in the latest dict() at the top of
+    this file and only return the latest for each device"""
+    for release in releases['result']:
+        for k, v in release.items():
+            for device, data in latest.items():
+                if k == 'filename' and v.startswith(device):
+                    if int(latest[device]['timestamp']) < int(release['timestamp']):
+                        latest[device] = release
+    return latest
+
+def prepareFactoryData(releases):
+    for device, data in releases.items():
+        releases[device]['factory_url'] = releases[device]['url'].replace('ota_update', 'factory').replace('zip', 'tar.xz')
+        releases[device]['factory_signature_url'] = "".join([releases[device]['factory_url'], '.sig'])
+        releases[device]['factory_filename'] = releases[device]['filename'].replace('ota_update', 'factory').replace('zip', 'tar.xz')
+        releases[device]['factory_signature_filename'] = "".join([releases[device]['factory_filename'], '.sig'])
+    return releases
+
+def filterDevices(releases):
+    filtered = dict()
+    for device in args.devices:
+        filtered[device] = releases[device]
+    return filtered
+
+def downloadFactoryImage(releases):
+    for device, data in releases.items():
+        if not exists(data['factory_filename']):
+            print("Found new factory image, downloading now:", data['factory_filename'])
+
+            with open(data['factory_filename'], 'wb') as file:
+                ota_file = get(data['factory_url'])
+                file.write(ota_file.content)
+
+        if not exists(data['factory_signature_filename']):
+            print("Found new factory image signature, downloading now:", data['factory_signature_filename'])
+            with open(data['factory_signature_filename'], 'wb') as file:
+                ota_file = get(data['factory_signature_url'])
+                file.write(ota_file.content)
+
+def validateDownloads(releases):
+    for device, data in releases.items():
+        if exists(data['factory_filename']) and exists(data['factory_signature_filename']):
+            print('Validating', data['factory_filename'])
+            try:
+                run(['gpg', data['factory_signature_filename']], check=True)
+            except CalledProcessError:
+                print('There was a problem validating the signature.')
+
+def main():
+    releases = filterDevices( prepareFactoryData( filterByLatest( getReleases())))
+    downloadFactoryImage(releases)
+    validateDownloads(releases)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Download the latest release for given device(s).')
+    parser.add_argument('devices', metavar='device', type=str, nargs='+', help=", ".join(latest.keys()))
+    args = parser.parse_args()
+
+    main()

--- a/install-packages.sh
+++ b/install-packages.sh
@@ -24,7 +24,7 @@ do
 done
 
 adb shell "mkdir /sdcard/MyAppList"
-adb push myapplist*xml /sdcard/MyAppList/
+adb push "${MYAPPLIST:-myapplist*xml}" /sdcard/MyAppList/
 
 echo "Disabling captive portal detection"
 adb shell "settings put global captive_portal_detection_enabled 0"

--- a/re-sign.sh
+++ b/re-sign.sh
@@ -31,16 +31,17 @@ then
   $TOOL_PATH/simg2img system.img system.img.raw
 fi
 
-
-echo "We now need sudo to install the OrWall startup script..."
-mkdir -p system
-sudo mount system.img.raw system
-sudo cp ../orwall-userinit.sh system/bin/oem-iptables-init.sh
-# system/sbin/svc has u:object_r:system_file:s0, which is convenient since
-# the host selinux may not understand that context
-sudo chcon --reference=system/bin/svc system/bin/oem-iptables-init.sh
-sudo chmod 755 system/bin/oem-iptables-init.sh
-sudo umount system
+if [ $NO_TOR -eq 0 ]; then
+  echo "We now need sudo to install the OrWall startup script..."
+  mkdir -p system
+  sudo mount system.img.raw system
+  sudo cp ../orwall-userinit.sh system/bin/oem-iptables-init.sh
+  # system/sbin/svc has u:object_r:system_file:s0, which is convenient since
+  # the host selinux may not understand that context
+  sudo chcon --reference=system/bin/svc system/bin/oem-iptables-init.sh
+  sudo chmod 755 system/bin/oem-iptables-init.sh
+  sudo umount system
+fi
 
 SYSTEM_SIZE=$($TOOL_PATH/ext2simg -v system.img.raw system-signed.img | grep "Size: " | cut -d: -f2)
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,18 +1,106 @@
 #!/bin/bash
+# vim:ts=2 sw=2 sts=2 expandtab:
 
 set -e
 
-if [ $# -ne 1 -a $# -ne 3 ]
-then
-  echo "Usage: $0 <copperhead_factory_dir> [<gapps.zip>] [<twrp.img>]"
+usage() {
+  echo "Usage: $0 [-h] -c <copperhead_factory_dir> [-g <gapps.zip> -r <twrp.img>] [--no-tor] "
+  echo
+  echo "Required arguments:"
+  echo "  -c|--copperhead          Path to unpacked factory image for your device."
+  echo
+  echo "Optional arguments"
+  echo "  -a|--myapplist           Path to MyAppList XML file.  Defaults to the one in the repository."
+  echo "  -g|--gapps <gapps.zip>   Path to GApps.zip you wish to use."
+  echo "  -h|--help                This usage output."
+  echo "  -r|--recovery <twrp.img> Path to TWRP recovery image."
+  echo "  -T|--no-tor              Don't install orbot or orwall."
   exit 1
+}
+
+# Use GNU getopt to capture arguments as it allows us to have long options
+# which the bash builtin getopts doesn't support.  We also still support the
+# old # positional arguments for now, but don't advertise them in the usage().
+TEMP=$(getopt -o 'ha:c:g:r:T::' --long 'help,myapplist,copperhead:,gapps:,recovery:,no-tor::' -- "$@")
+[ $? -ne 0 ] && usage
+eval set -- "$TEMP"; unset TEMP
+# Set defaults
+NO_TOR=0
+# Parse the args
+while true; do
+  case "$1" in
+    '-a'|'--myapplist')
+      if [ -r "$2" ]; then
+        MYAPPLIST="$2"
+        shift 2
+        continue
+      else
+        echo "File not found: '$2'"
+        exit 1
+      fi
+      ;;
+    '-c'|'--copperhead')
+      COPPERHEAD_DIR=$2
+      shift 2;
+      continue
+      ;;
+    '-g'|'--gapps')
+      GAPPS_ZIP=$2
+      shift 2
+      continue
+      ;;
+    '-r'|'--recovery')
+      TWRP_IMG=$2
+      shift 2
+      continue
+      ;;
+    '-T'|'--no-tor')
+      NO_TOR=1
+      shift
+      continue
+      ;;
+    '-h'|'--help')
+      usage
+      ;;
+    '-*')
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    '--')
+      shift
+      break
+      ;;
+    *)
+      POSITIONAL="$POSITIONAL $1"
+      shift
+      continue
+      ;;
+  esac
+done
+
+set +e
+# Backwards compatibility for positional arguments
+[ -z $COPPERHEAD_DIR ] && [ -n $1 ] && COPPERHEAD_DIR=$1 && shift
+[ -z $GAPPS_ZIP ] && [ -n $1 ] && GAPPS_ZIP=$1 && shift
+[ -z $TWRP_IMG ] && [ -n $1 ] && TWRP_IMG=$1 && shift
+set -e
+
+export MYAPPLIST
+export COPPERHEAD_DIR
+export GAPPS_ZIP
+export TWRP_IMG
+export NO_TOR
+
+# Bail out if no Copperhead directory was provided
+[ -z ${COPPERHEAD_DIR} ] && usage
+
+# Enforce none or both of GAPPS_ZIP and TWRP_IMG being supplied
+if [[ -n $GAPPS_ZIP && -z $TWRP_IMG ]] || [[ -z $GAPPS_ZIP && -n $TWRP_IMG ]]; then
+  usage
 fi
 
-COPPERHEAD_DIR=$1
 SUPERBOOT_DIR=$PWD/helper-repos/super-bootimg
 SIMG2IMG_DIR=$PWD/helper-repos/android-simg2img
-GAPPS_ZIP=$2
-TWRP_IMG=$3
 
 ./clone-helper-repos.sh $SUPERBOOT_DIR $SIMG2IMG_DIR
 ./fetch-apks.sh

--- a/update.sh
+++ b/update.sh
@@ -142,6 +142,8 @@ then
   echo "You need to unplug and replug your device after starting sideload.."
   echo -n "[Hit Enter to continue...]"
   read junk
+  # A sleep is needed to ensure the device is successfully detected after plugging back in
+  sleep 5
 fi
 
 adb sideload ${DEVICE}-update-signed.zip

--- a/update.sh
+++ b/update.sh
@@ -2,16 +2,72 @@
 
 set -e
 
-if [ $# -ne 2 ]
-then
-  echo "Usage: $0 <new_copperhead_factory_dir> <device_type>"
+usage() {
+  echo "Usage: $0 -c <new_copperhead_factory_dir> -d <device_type> [--no-tor]"
   exit 1
-fi
+}
 
-COPPERHEAD_DIR=$1
+# Use GNU getopt to capture arguments as it allows us to have long options
+# which the bash builtin getopts doesn't support.  We also still support the
+# old # positional arguments for now, but don't advertise them in the usage().
+TEMP=$(getopt -o 'hc:d:T::' --long 'help,copperhead:,device:,no-tor::' -- "$@")
+[ $? -ne 0 ] && usage
+eval set -- "$TEMP"; unset TEMP
+# Set defaults
+NO_TOR=0
+# Parse the args
+while true; do
+  case "$1" in
+    '-c'|'--copperhead')
+      COPPERHEAD_DIR=$2
+      shift 2;
+      continue
+      ;;
+    '-d'|'--device')
+      DEVICE=$2
+      shift 2
+      continue
+      ;;
+    '-T'|'--no-tor')
+      NO_TOR=1
+      shift
+      continue
+      ;;
+    '-h'|'--help')
+      usage
+      ;;
+    '-*')
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    '--')
+      shift
+      break
+      ;;
+    *)
+      POSITIONAL="$POSITIONAL $1"
+      shift
+      continue
+      ;;
+  esac
+done
+
+set +e
+# Backwards compatibility for positional arguments
+[ -z $COPPERHEAD_DIR ] && [ -n $1 ] && COPPERHEAD_DIR=$1 && shift
+[ -z $DEVICE ] && [ -n $1 ] && DEVICE=$1 && shift
+set -e
+
+export COPPERHEAD_DIR
+export DEVICE
+export NO_TOR
+
+# Bail out if no Copperhead directory was provided or no device defined
+[ -z ${COPPERHEAD_DIR} ] && usage
+[ -z ${DEVICE} ] && usage
+
 SUPERBOOT_DIR=$PWD/helper-repos/super-bootimg
 SIMG2IMG_DIR=$PWD/helper-repos/android-simg2img
-DEVICE=$2
 
 #if [ ! -f "./packages/gapps-delta.tar.xz" ]
 #then


### PR DESCRIPTION
### Add script to fetch and validate latest images

The script gets the list of releases from the CopperheadOS site and
pulls down the latest image for a given device or devices.  After bing
fetched the signature is downloaded and validated.

GPG keys are not fetched automatically, so if the user doesn't have the
public key of the signer they will see a "valid signature" message, but
no indication of trust.

The implementation to work out the image file name is based on the
javascript used by the CopperheadOS site.

### Add support for CLI flags, and a new --no-tor option

GNU getopt has been implemented as the CLI flags parser.  While not a
bash builtin this is widely available and comes by default with Ubuntu
Yakkety and Zesty.

The old positional args are still silently supported, however the usage
output will direct the user towards using the CLI flags now.

Both the `run_all.sh` and `update.sh` scripts have been updated, with
the downstream scripts consuming the flags via exported env vars.

The first feature implemented is the ability to skip installing tor
related tools, i.e. orwall and orbot.  The implementation is slightly
crude, however for now it works well.  This can be refactored later.

There are also some minor text updates included too.

While there is a default myapplist.xml file in the repository, it is now
possible for the user to provide their own via CLI flags.  The getopt
option was added in the previous commit and this is the implementation.

### Make flashing more robust with `sleep`

A couple of places needed a slightly longer wait to avoid failures
during flashing.

### Ignore transient files

We generate many transient files that shouldn't be committed to the
repository, so we should ignore these.